### PR TITLE
fix(release): copy prompt contents not directory into staging zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           # --- Copilot layer: .github/ files ---
 
           # Prompts
-          cp -r .github/prompts staging/.github/prompts
+          cp -r .github/prompts/. staging/.github/prompts/
 
           # GSD-prefixed instruction files only (|| true: dir may be empty or missing)
           find .github/instructions -maxdepth 1 \( -name "gsd-*.instructions.md" -o -name "gsd.*.md" \) \


### PR DESCRIPTION
This pull request makes a small adjustment to the release workflow for copying prompt files. The change ensures that all contents (including hidden files) from `.github/prompts` are copied correctly to the staging area.

* Updated the `cp` command in `.github/workflows/release.yml` to use `.github/prompts/.` as the source and `staging/.github/prompts/` as the destination, ensuring all prompt files—including hidden ones—are copied.
## What

<!-- One sentence: what does this PR do? -->

## Why

<!-- One sentence: why is this change needed? -->

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Checklist

- [ ] Follows GSD style (no enterprise patterns, no filler)
- [ ] Updates CHANGELOG.md for user-facing changes
- [ ] No unnecessary dependencies added
- [ ] Works on Windows (backslash paths tested)

## Breaking Changes

None
