### PR TITLE
fix(sync): switch auto-merge from --squash to --merge

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -289,7 +289,9 @@ jobs:
             echo "pr_number=${EXISTING_PR}" >> "$GITHUB_OUTPUT"
           fi
 
-      # SYNC-01/02: Enable auto-merge on the PR (squash strategy keeps main history clean).
+      # SYNC-01/02: Enable auto-merge on the PR (merge commit strategy preserves upstream commit SHAs
+      # in main's ancestry, which is required for GitHub's 'X commits behind upstream' indicator to
+      # clear correctly after merge. Squash would create a new SHA and main would always appear behind.)
       # This is a no-op when auto-merge is already enabled; safe to run on every sync.
       - name: Enable auto-merge on sync PR
         if: steps.detect.outputs.no_changes != 'true' && steps.create_pr.outputs.pr_number != ''
@@ -297,7 +299,7 @@ jobs:
           gh pr merge "${{ steps.create_pr.outputs.pr_number }}" \
             --repo "$GITHUB_REPOSITORY" \
             --auto \
-            --squash
+            --merge
           echo "Auto-merge enabled on PR #${{ steps.create_pr.outputs.pr_number }}."
 
   repair:


### PR DESCRIPTION
Squash merge creates a new commit SHA on main that does not include the upstream commits as ancestors. GitHub's 'X commits behind' indicator compares commit ancestry, not file content  so main always showed as behind even after the PR merged successfully.

--merge creates a merge commit that preserves the upstream commit SHAs as parents of main, clearing the behind indicator correctly.

## What

<!-- One sentence: what does this PR do? -->

## Why

<!-- One sentence: why is this change needed? -->

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Checklist

- [ ] Follows GSD style (no enterprise patterns, no filler)
- [ ] Updates CHANGELOG.md for user-facing changes
- [ ] No unnecessary dependencies added
- [ ] Works on Windows (backslash paths tested)

## Breaking Changes

None
