### PR TITLE
Development

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -818,7 +818,7 @@ jobs:
           3. Run: node scripts/generate-prompts.mjs
           4. Run: node scripts/verify-prompts.mjs
           5. Both must pass.
-          6. Open a PR from your working branch targeting base: automated/upstream-sync (NOT main).
+          6. Open a PR from the copilot/* branch you created in this task targeting base: automated/upstream-sync (NOT main).
           7. PR title: "sync: upstream changes (conflict resolved by agent)"
           8. If the conflict cannot be resolved autonomously, write "DEAD_END" to /tmp/repair-dead-end.txt and stop.
 


### PR DESCRIPTION
This pull request makes improvements to the release handling logic in the `.github/workflows/upstream-sync.yml` workflow. The main focus is on ensuring that release IDs are valid and preventing errors or corrupted API calls due to invalid IDs.

Release ID validation improvements:

* Added a guard to ensure that the `RELEASE_ID` extracted from the GitHub API is a bare integer, preventing accidental use of error payloads or invalid values. (`.github/workflows/upstream-sync.yml`)
* Added a sanity check before patching the release body to ensure that `RELEASE_ID` is a valid numeric ID, with an explicit error message and abort if the check fails. (`.github/workflows/upstream-sync.yml`)

## What

<!-- One sentence: what does this PR do? -->

## Why

<!-- One sentence: why is this change needed? -->

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Checklist

- [ ] Follows GSD style (no enterprise patterns, no filler)
- [ ] Updates CHANGELOG.md for user-facing changes
- [ ] No unnecessary dependencies added
- [ ] Works on Windows (backslash paths tested)

## Breaking Changes

None
