### PR TITLE
fix(upstream-sync): improve agent authentication validation and refin…

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -763,21 +763,25 @@ jobs:
         if: steps.preflight.outputs.skip != 'true'
         id: agent_auth
         run: |
-          # gh agent-task requires a classic OAuth PAT (ghp_...).
-          # Fine-grained tokens (github_pat_...) and GITHUB_TOKEN are rejected.
-          # Validate early so failures surface clearly rather than silently
-          # exhausting all repair strategies.
-          AUTH_STATUS=$(gh auth status 2>&1 || true)
-          TOKEN_TYPE=$(echo "$AUTH_STATUS" | grep -oP '(ghp_|github_pat_|ghs_)[^\s]+' | head -1 || echo "")
-          if echo "$TOKEN_TYPE" | grep -q '^github_pat_'; then
+          # gh agent-task requires a classic OAuth PAT (ghp_...) AND the token
+          # must be stored via gh auth login — setting GH_TOKEN env var alone is
+          # not sufficient for this subcommand.
+
+          # 1. Detect token type directly from the env var (fast, no API call)
+          if echo "${GH_TOKEN:-}" | grep -q '^github_pat_'; then
             echo "::error::COPILOT_PAT is a fine-grained token (github_pat_...). gh agent-task requires a classic OAuth PAT (ghp_...). Regenerate COPILOT_PAT as a classic PAT with repo + codespace scopes."
             echo "agent_auth_ok=false" >> "$GITHUB_OUTPUT"
-          elif [ -z "$TOKEN_TYPE" ]; then
-            echo "::warning::Could not determine COPILOT_PAT token type from gh auth status. Proceeding, but agent-task calls may fail."
-            echo "agent_auth_ok=unknown" >> "$GITHUB_OUTPUT"
-          else
-            echo "Token type looks OK (${TOKEN_TYPE:0:6}...). Proceeding."
+            exit 0
+          fi
+
+          # 2. Log in explicitly — gh agent-task does not respect GH_TOKEN env var;
+          #    it requires credentials in the gh credential store.
+          if echo "${GH_TOKEN:-}" | gh auth login --with-token --hostname github.com 2>&1; then
+            echo "Successfully logged in with COPILOT_PAT."
             echo "agent_auth_ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::gh auth login failed with COPILOT_PAT. Token may be expired or lack required scopes (repo, codespace)."
+            echo "agent_auth_ok=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Resolve merge conflict via Copilot agent
@@ -907,6 +911,15 @@ jobs:
             echo "repair_succeeded=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
+          # Record the branch state BEFORE any agent work.
+          # The guard uses this to diff only what the agent actually changed,
+          # rather than comparing the whole branch to upstream/main (which would
+          # produce false positives for files the fork legitimately diverges on).
+          PRE_REPAIR_SHA=$(git rev-parse HEAD)
+          echo "$PRE_REPAIR_SHA" > /tmp/pre-repair-sha
+          echo "pre_repair_sha=${PRE_REPAIR_SHA}" >> "$GITHUB_OUTPUT"
+          echo "Pre-repair SHA: ${PRE_REPAIR_SHA}"
 
           STRATEGIES=("basic_verifier_fix" "contextual_generative_fix" "full_rewrite" "alt_approach")
           STRATEGY_IDX=0
@@ -1148,6 +1161,8 @@ jobs:
 
       - name: Filesystem guard (post-repair)
         if: steps.preflight.outputs.skip != 'true' && steps.repair_loop.outputs.repair_needed == 'true'
+        env:
+          PRE_REPAIR_BASELINE: ${{ steps.repair_loop.outputs.pre_repair_sha }}
         run: |
           bash scripts/guard-upstream-files.sh post-commit
 

--- a/scripts/guard-upstream-files.sh
+++ b/scripts/guard-upstream-files.sh
@@ -33,12 +33,22 @@ if [ "$MODE" = "pre-commit" ]; then
   fi
   echo "Filesystem guard (pre-commit): no violations."
 elif [ "$MODE" = "post-commit" ]; then
-  # Check files changed relative to upstream/main.
-  # Using upstream/main (not origin/main) as the baseline because the
-  # automated/upstream-sync branch legitimately diverges from origin/main for all
-  # upstream-owned files — that's by design. We only want to catch files the repair
-  # agent incorrectly modified relative to what upstream already has.
-  git diff --name-only upstream/main HEAD | sort > /tmp/committed-files.txt
+  # Determine the diff baseline.
+  # When called from the repair job, PRE_REPAIR_BASELINE contains the SHA recorded
+  # before any agent work ran. Using it means we only flag files the agent actually
+  # changed — not all files the fork legitimately diverges from upstream on.
+  # Fall back to upstream/main when no baseline is available (e.g. manual invocations).
+  if [ -n "${PRE_REPAIR_BASELINE:-}" ]; then
+    BASELINE="$PRE_REPAIR_BASELINE"
+    echo "Using pre-repair baseline: $BASELINE"
+  elif [ -f /tmp/pre-repair-sha ]; then
+    BASELINE=$(cat /tmp/pre-repair-sha)
+    echo "Using pre-repair baseline from file: $BASELINE"
+  else
+    BASELINE="upstream/main"
+    echo "No pre-repair baseline found; falling back to upstream/main."
+  fi
+  git diff --name-only "$BASELINE" HEAD | sort > /tmp/committed-files.txt
   VIOLATIONS=$(comm -12 /tmp/upstream-owned-filtered.txt /tmp/committed-files.txt || true)
   if [ -n "$VIOLATIONS" ]; then
     echo "::error::Filesystem guard (post-commit): repair agent committed changes to upstream-owned files:"


### PR DESCRIPTION

This pull request improves the reliability and accuracy of the upstream sync workflow, particularly in how it authenticates tokens and detects changes made by the repair agent. The main focus is on ensuring that only the files actually modified by the agent are checked for violations, preventing false positives due to legitimate branch divergence, and making token validation more robust.

**Authentication improvements:**

* The GitHub Actions workflow now validates the token type directly from the `GH_TOKEN` environment variable and performs an explicit login with `gh auth login`, ensuring that only classic OAuth PATs are used and that credentials are stored correctly for agent tasks.

**Change detection and guard accuracy:**

* The workflow records the commit SHA before any agent repairs and uses this as a baseline for post-repair checks, ensuring that only files actually changed by the agent are flagged for violations. This avoids comparing the entire branch to upstream, which could lead to false positives.
* The `guard-upstream-files.sh` script is updated to use the pre-repair SHA as the diff baseline when available, falling back to `upstream/main` only if necessary. This makes the guard check more precise and context-aware.
* The filesystem guard step in the workflow is updated to pass the pre-repair SHA to the script via the `PRE_REPAIR_BASELINE` environment variable, connecting the recorded baseline to the guard logic.

## What

<!-- One sentence: what does this PR do? -->

## Why

<!-- One sentence: why is this change needed? -->

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Checklist

- [ ] Follows GSD style (no enterprise patterns, no filler)
- [ ] Updates CHANGELOG.md for user-facing changes
- [ ] No unnecessary dependencies added
- [ ] Works on Windows (backslash paths tested)

## Breaking Changes

None
