### PR TITLE
fix(upstream-sync): update agent-task creation to unset GH_TOKEN and …

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -404,7 +404,7 @@ jobs:
           PROMPT_EOF
 
           echo "Invoking Copilot proactive adaptation agent..."
-          gh agent-task create \
+          env -u GH_TOKEN -u GITHUB_TOKEN gh agent-task create \
             --repo "$GITHUB_REPOSITORY" \
             --base "automated/upstream-sync" \
             --follow \
@@ -780,7 +780,7 @@ jobs:
           #    the environment, so we must capture the token value and unset the
           #    env var before calling auth login.
           COPILOT_TOKEN="${GH_TOKEN:-}"
-          if echo "$COPILOT_TOKEN" | env -u GH_TOKEN gh auth login --with-token --hostname github.com 2>&1; then
+          if echo "$COPILOT_TOKEN" | env -u GH_TOKEN -u GITHUB_TOKEN gh auth login --with-token --hostname github.com 2>&1; then
             echo "Successfully logged in with COPILOT_PAT."
             echo "agent_auth_ok=true" >> "$GITHUB_OUTPUT"
           else
@@ -863,7 +863,7 @@ jobs:
           \`\`\`
           PROMPT_EOF
 
-          gh agent-task create \
+          env -u GH_TOKEN -u GITHUB_TOKEN gh agent-task create \
             --repo "$GITHUB_REPOSITORY" \
             --base "automated/upstream-sync" \
             --follow \
@@ -1057,9 +1057,11 @@ jobs:
             PRE_AGENT_SHA=$(git rev-parse HEAD 2>/dev/null || echo "")
 
             # Invoke Copilot coding agent
-            # Unset GH_TOKEN so gh agent-task uses the stored credential (from
-            # the 'Validate agent-task auth' step) rather than the env var.
-            AGENT_TASK_OUTPUT=$(env -u GH_TOKEN gh agent-task create \
+            # Unset GH_TOKEN and GITHUB_TOKEN so gh agent-task uses the stored
+            # credential (from 'Validate agent-task auth') rather than the env
+            # vars. GitHub Actions injects both; gh CLI prefers env vars over
+            # the credential store, so both must be cleared.
+            AGENT_TASK_OUTPUT=$(env -u GH_TOKEN -u GITHUB_TOKEN gh agent-task create \
               --repo "$GITHUB_REPOSITORY" \
               --base "automated/upstream-sync" \
               --follow \


### PR DESCRIPTION
…GITHUB_TOKEN for proper authentication

This pull request updates the `.github/workflows/upstream-sync.yml` workflow to improve how authentication tokens are handled when invoking the `gh agent-task` and `gh auth login` commands. The main goal is to ensure that the `gh` CLI uses the stored credentials instead of environment variables, which increases security and reliability in GitHub Actions environments.

**Improvements to authentication handling:**

* All invocations of `gh agent-task create` now explicitly unset both `GH_TOKEN` and `GITHUB_TOKEN` environment variables to force the use of stored credentials, addressing the fact that GitHub Actions injects both tokens and the `gh` CLI prefers environment variables over the credential store. [[1]](diffhunk://#diff-f21bf02175f33f2522bf5ac7944d2999c7f4ea8b8542afe361a9800eda3580e9L407-R407) [[2]](diffhunk://#diff-f21bf02175f33f2522bf5ac7944d2999c7f4ea8b8542afe361a9800eda3580e9L866-R866) [[3]](diffhunk://#diff-f21bf02175f33f2522bf5ac7944d2999c7f4ea8b8542afe361a9800eda3580e9L1060-R1064)
* The `gh auth login` command is also updated to unset both `GH_TOKEN` and `GITHUB_TOKEN` to ensure it doesn't accidentally use an injected token instead of the intended credential.

## What

<!-- One sentence: what does this PR do? -->

## Why

<!-- One sentence: why is this change needed? -->

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Checklist

- [ ] Follows GSD style (no enterprise patterns, no filler)
- [ ] Updates CHANGELOG.md for user-facing changes
- [ ] No unnecessary dependencies added
- [ ] Works on Windows (backslash paths tested)

## Breaking Changes

None
