### PR TITLE
fix(upstream-sync): enhance error messages for COPILOT_PAT token vali…

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -778,7 +778,7 @@ jobs:
 
           # 1. Detect token type directly from the env var (fast, no API call)
           if echo "${GH_TOKEN:-}" | grep -q '^github_pat_'; then
-            echo "::error::COPILOT_PAT is a fine-grained token (github_pat_...). gh agent-task requires a classic OAuth PAT (ghp_...). Regenerate COPILOT_PAT as a classic PAT with repo + codespace scopes."
+            echo "::error::COPILOT_PAT is a fine-grained token (github_pat_...). gh agent-task requires a classic OAuth PAT (ghp_...) with scopes: repo, codespace, workflow. Regenerate COPILOT_PAT as a classic PAT at github.com/settings/tokens."
             echo "agent_auth_ok=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -789,13 +789,26 @@ jobs:
           #    the environment, so we must capture the token value and unset the
           #    env var before calling auth login.
           COPILOT_TOKEN="${GH_TOKEN:-}"
-          if echo "$COPILOT_TOKEN" | env -u GH_TOKEN -u GITHUB_TOKEN gh auth login --with-token --hostname github.com 2>&1; then
-            echo "Successfully logged in with COPILOT_PAT."
-            echo "agent_auth_ok=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::error::gh auth login failed with COPILOT_PAT. Token may be expired or lack required scopes (repo, codespace)."
+          if ! echo "$COPILOT_TOKEN" | env -u GH_TOKEN -u GITHUB_TOKEN gh auth login --with-token --hostname github.com 2>&1; then
+            echo "::error::gh auth login failed with COPILOT_PAT. Token may be expired or lack required scopes (repo, codespace, workflow)."
             echo "agent_auth_ok=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          echo "Successfully logged in with COPILOT_PAT."
+
+          # 3. Verify required scopes — gh agent-task REQUIRES 'codespace' scope
+          #    in addition to 'repo'. Missing this scope produces the misleading
+          #    error "this command requires an OAuth token" even with a valid ghp_...
+          #    token. Check now and fail fast with a clear message.
+          AUTH_SCOPES=$(env -u GH_TOKEN -u GITHUB_TOKEN gh auth status 2>&1 || true)
+          echo "Token info: $AUTH_SCOPES"
+          if ! echo "$AUTH_SCOPES" | grep -q "'codespace'"; then
+            echo "::error::COPILOT_PAT is missing the 'codespace' scope. gh agent-task requires: repo, codespace, workflow. Current scopes: $(echo "$AUTH_SCOPES" | grep 'Token scopes' || echo 'unknown'). Regenerate COPILOT_PAT on github.com/settings/tokens and add the 'codespace' scope."
+            echo "agent_auth_ok=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "agent_auth_ok=true" >> "$GITHUB_OUTPUT"
 
       - name: Resolve merge conflict via Copilot agent
         if: steps.preflight.outputs.skip != 'true' && needs.sync.outputs.merge_conflict == 'true'


### PR DESCRIPTION
…dation and required scopes

This pull request improves the authentication checks and error messaging for the `COPILOT_PAT` token in the `.github/workflows/upstream-sync.yml` workflow. The main focus is to ensure that the token used is a classic OAuth PAT with the correct scopes and to provide clearer, more actionable error messages when authentication fails.

**Authentication and error handling improvements:**

* Updated the error message when a fine-grained token is detected to specify that a classic OAuth PAT with `repo`, `codespace`, and `workflow` scopes is required, and provided a direct link to GitHub's token generation page.
* Changed the logic to explicitly fail and output an error if `gh auth login` fails, clarifying that the token may be expired or missing required scopes.
* Added a step to verify that the token includes the `codespace` scope, with a clear error message if it's missing, and listed all required scopes (`repo`, `codespace`, `workflow`).
* Improved output and error handling to ensure `agent_auth_ok` is only set to `true` when all checks pass.

## What

<!-- One sentence: what does this PR do? -->

## Why

<!-- One sentence: why is this change needed? -->

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Checklist

- [ ] Follows GSD style (no enterprise patterns, no filler)
- [ ] Updates CHANGELOG.md for user-facing changes
- [ ] No unnecessary dependencies added
- [ ] Works on Windows (backslash paths tested)

## Breaking Changes

None
