### PR TITLE
fix(upstream-sync): refactor Copilot agent invocation to use issue as…

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -419,6 +419,7 @@ jobs:
             --label "upstream-sync" \
             2>/dev/null || echo "")
           ADAPT_ISSUE=$(echo "$ADAPT_ISSUE_URL" | grep -oP '/issues/\K[0-9]+' || echo "")
+          [[ "$ADAPT_ISSUE" =~ ^[0-9]+$ ]] || ADAPT_ISSUE=""
 
           if [ -z "$ADAPT_ISSUE" ]; then
             echo "::warning::Failed to create Copilot adaptation issue. Copilot coding agent may not be enabled for this repository."
@@ -963,6 +964,7 @@ jobs:
             --label "upstream-sync" \
             2>/dev/null || echo "")
           CONFLICT_ISSUE=$(echo "$CONFLICT_ISSUE_URL" | grep -oP '/issues/\K[0-9]+' || echo "")
+          [[ "$CONFLICT_ISSUE" =~ ^[0-9]+$ ]] || CONFLICT_ISSUE=""
 
           if [ -n "$CONFLICT_ISSUE" ]; then
             CONFLICT_ISSUE_CREATED_AT=$(gh issue view "$CONFLICT_ISSUE" \
@@ -1220,6 +1222,7 @@ jobs:
               --label "upstream-sync" \
               2>/dev/null || echo "")
             REPAIR_ISSUE=$(echo "$REPAIR_ISSUE_URL" | grep -oP '/issues/\K[0-9]+' || echo "")
+            [[ "$REPAIR_ISSUE" =~ ^[0-9]+$ ]] || REPAIR_ISSUE=""
 
             if [ -z "$REPAIR_ISSUE" ]; then
               echo "::warning::Failed to create Copilot repair issue. Copilot coding agent may not be enabled for this repository, or COPILOT_PAT lacks 'repo' scope."


### PR DESCRIPTION
…signment for proactive adaptation and conflict resolution
This pull request updates the GitHub Actions workflow for `upstream-sync` to change how the Copilot coding agent is triggered in CI. The workflow now uses GitHub issue assignment (assigning issues to the `copilot` user) instead of the `gh agent-task create` command, which is not compatible with CI environments due to its requirement for an interactive OAuth login. The changes also simplify token validation and clarify required permissions for the Copilot PAT. These updates make the automation more robust and compatible with GitHub's documented practices.

**Copilot agent invocation and token validation:**

* Replaces all uses of `gh agent-task create` with the creation of GitHub issues assigned to `copilot`, since `gh agent-task` requires an interactive OAuth token and is not suitable for CI workflows. The workflow now polls for a Copilot-generated PR after creating the issue, and closes the issue once processed. [[1]](diffhunk://#diff-f21bf02175f33f2522bf5ac7944d2999c7f4ea8b8542afe361a9800eda3580e9L406-R451) [[2]](diffhunk://#diff-f21bf02175f33f2522bf5ac7944d2999c7f4ea8b8542afe361a9800eda3580e9L888-R949) [[3]](diffhunk://#diff-f21bf02175f33f2522bf5ac7944d2999c7f4ea8b8542afe361a9800eda3580e9L1090-R1188)
* Simplifies and clarifies authentication checks: only classic OAuth PATs (`ghp_...`) with the `repo` scope are accepted, and the need for `codespace` and `workflow` scopes is removed. The workflow now provides clearer error messages and early exits if the token is missing or of the wrong type.

**Workflow robustness and user feedback:**

* Adds detailed logging and warnings if the Copilot agent is not enabled, the token is invalid, or no PR is opened within the polling window. [[1]](diffhunk://#diff-f21bf02175f33f2522bf5ac7944d2999c7f4ea8b8542afe361a9800eda3580e9L406-R451) [[2]](diffhunk://#diff-f21bf02175f33f2522bf5ac7944d2999c7f4ea8b8542afe361a9800eda3580e9L888-R949) [[3]](diffhunk://#diff-f21bf02175f33f2522bf5ac7944d2999c7f4ea8b8542afe361a9800eda3580e9L1090-R1188)
* Ensures that Copilot-related issues are closed automatically with a comment after processing, keeping the repository clean. [[1]](diffhunk://#diff-f21bf02175f33f2522bf5ac7944d2999c7f4ea8b8542afe361a9800eda3580e9L406-R451) [[2]](diffhunk://#diff-f21bf02175f33f2522bf5ac7944d2999c7f4ea8b8542afe361a9800eda3580e9L888-R949) [[3]](diffhunk://#diff-f21bf02175f33f2522bf5ac7944d2999c7f4ea8b8542afe361a9800eda3580e9L1090-R1188)
## What

<!-- One sentence: what does this PR do? -->

## Why

<!-- One sentence: why is this change needed? -->

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Checklist

- [ ] Follows GSD style (no enterprise patterns, no filler)
- [ ] Updates CHANGELOG.md for user-facing changes
- [ ] No unnecessary dependencies added
- [ ] Works on Windows (backslash paths tested)

## Breaking Changes

None
