### PR TITLE
fix(upstream-sync): simplify validation for COPILOT_PAT by removing s…

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -857,24 +857,13 @@ jobs:
             exit 0
           fi
 
-          # Validate that the classic PAT has the required 'repo' scope.
-          # gh auth status -t prints the token scopes on a dedicated line, e.g.:
-          #   Token scopes: repo, read:org
-          if ! gh auth status -t >/tmp/gh_auth_status 2>&1; then
-            echo "::error::gh auth status failed for COPILOT_PAT. Ensure the token is valid and has 'repo' scope."
-            cat /tmp/gh_auth_status || true
-            echo "agent_auth_ok=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if ! grep -E '^ *Token scopes: .*\brepo\b' /tmp/gh_auth_status >/dev/null 2>&1; then
-            echo "::error::COPILOT_PAT is a classic OAuth PAT but does not have the required 'repo' scope. Update the token at https://github.com/settings/tokens."
-            cat /tmp/gh_auth_status || true
-            echo "agent_auth_ok=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "COPILOT_PAT is a valid classic OAuth PAT with 'repo' scope. Ready for issue-based Copilot agent invocation."
+          # ghp_... prefix is sufficient to confirm this is a classic OAuth PAT.
+          # Scope validation via 'gh auth status' is NOT used here: when GH_TOKEN
+          # is set as an env var (as it is in this job), gh reports 'Token scopes: none'
+          # because scope metadata is only stored when using 'gh auth login'.
+          # If the token lacks 'repo' scope, 'gh issue create' will fail with a
+          # clear API error at the point of use.
+          echo "COPILOT_PAT is a valid classic OAuth PAT. Ready for issue-based Copilot agent invocation."
           echo "agent_auth_ok=true" >> "$GITHUB_OUTPUT"
 
       - name: Resolve merge conflict via Copilot agent


### PR DESCRIPTION
…cope checks
This pull request simplifies the authentication check for the Copilot agent in the `upstream-sync.yml` workflow. Instead of validating the token's `repo` scope using `gh auth status`, the script now only checks for the classic OAuth PAT prefix and relies on runtime errors for scope issues.

Authentication check simplification:

* Removed the explicit validation of the `repo` scope for the `COPILOT_PAT` token using `gh auth status`, since this check is unreliable when `GH_TOKEN` is set as an environment variable. Now, the script assumes the token is valid if it has the `ghp_...` prefix and will surface any scope issues at the time of API usage.
## What

<!-- One sentence: what does this PR do? -->

## Why

<!-- One sentence: why is this change needed? -->

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Checklist

- [ ] Follows GSD style (no enterprise patterns, no filler)
- [ ] Updates CHANGELOG.md for user-facing changes
- [ ] No unnecessary dependencies added
- [ ] Works on Windows (backslash paths tested)

## Breaking Changes

None
