### PR TITLE
fix(upstream-sync): update pre-repair SHA recording to improve diff a…

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -1074,6 +1074,15 @@ jobs:
           REPAIR_NEEDED=true
           CURRENT_ERRORS=$(cat /tmp/verify_initial.log | head -c 5000)
 
+          # Record the branch state NOW — before any self-heal commit or agent work.
+          # The guard step uses this as the diff baseline to see only what this job
+          # changed, rather than diffing the entire branch vs upstream/main (which
+          # would flag legitimately-merged upstream files as violations).
+          PRE_REPAIR_SHA=$(git rev-parse HEAD)
+          echo "$PRE_REPAIR_SHA" > /tmp/pre-repair-sha
+          echo "pre_repair_sha=${PRE_REPAIR_SHA}" >> "$GITHUB_OUTPUT"
+          echo "Pre-repair SHA: ${PRE_REPAIR_SHA}"
+
           # ── Self-heal pass ──────────────────────────────────────────────────────
           # Most failures are simply stale generated prompts. Re-running the
           # generator and committing is enough — no agent needed.
@@ -1110,15 +1119,6 @@ jobs:
             echo "repair_succeeded=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-
-          # Record the branch state BEFORE any agent work.
-          # The guard uses this to diff only what the agent actually changed,
-          # rather than comparing the whole branch to upstream/main (which would
-          # produce false positives for files the fork legitimately diverges on).
-          PRE_REPAIR_SHA=$(git rev-parse HEAD)
-          echo "$PRE_REPAIR_SHA" > /tmp/pre-repair-sha
-          echo "pre_repair_sha=${PRE_REPAIR_SHA}" >> "$GITHUB_OUTPUT"
-          echo "Pre-repair SHA: ${PRE_REPAIR_SHA}"
 
           STRATEGIES=("basic_verifier_fix" "contextual_generative_fix" "full_rewrite" "alt_approach")
           STRATEGY_IDX=0


### PR DESCRIPTION
…ccuracy for self-heal operations
This pull request updates the `upstream-sync.yml` GitHub Actions workflow to improve how the workflow records the branch state before making automated repairs. The main change is moving the step that captures the current commit SHA to an earlier point in the workflow, ensuring that only changes made by the self-heal or agent steps are detected later.

Workflow improvements:

* Moved the recording of the pre-repair commit SHA (`PRE_REPAIR_SHA`) to occur immediately before any self-heal or agent work, rather than after the self-heal pass. This ensures that the guard step only detects changes made by the workflow itself, avoiding false positives from legitimate upstream merges. [[1]](diffhunk://#diff-f21bf02175f33f2522bf5ac7944d2999c7f4ea8b8542afe361a9800eda3580e9R1077-R1085) [[2]](diffhunk://#diff-f21bf02175f33f2522bf5ac7944d2999c7f4ea8b8542afe361a9800eda3580e9L1114-L1122)
## What

<!-- One sentence: what does this PR do? -->

## Why

<!-- One sentence: why is this change needed? -->

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Checklist

- [ ] Follows GSD style (no enterprise patterns, no filler)
- [ ] Updates CHANGELOG.md for user-facing changes
- [ ] No unnecessary dependencies added
- [ ] Works on Windows (backslash paths tested)

## Breaking Changes

None
