### PR TITLE
fix(upstream-sync): ensure PR creation for automated upstream sync wh…

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -1099,7 +1099,7 @@ jobs:
               # Ensure a PR exists to merge automated/upstream-sync → main.
               # The sync job creates the PR when no verifier errors exist at sync time;
               # when repair is needed the sync job does NOT create a PR, so we must.
-              EXISTING_PR=$(gh pr list --repo "$GITHUB_REPOSITORY" \
+              EXISTING_PR=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
                 --head "automated/upstream-sync" --json number --jq '.[0].number' 2>/dev/null || echo "")
               if [ -z "$EXISTING_PR" ]; then
                 echo "No existing PR for automated/upstream-sync — creating one..."


### PR DESCRIPTION
…en repair is needed
This pull request updates the upstream sync workflow to improve automation and reliability when handling upstream changes and subsequent repairs. The main changes ensure that a pull request is always created when repair is needed and that the release mirror job waits for both sync and repair jobs to finish, preventing inconsistencies.

**Workflow automation improvements:**

* Added logic to the `repair` job in `.github/workflows/upstream-sync.yml` to check for an existing pull request from `automated/upstream-sync` to `main`, and to create one if it doesn't exist. This ensures that a PR is always present after a successful repair, even if the original sync job did not create one.

**Job dependency adjustments:**

* Updated the `release-mirror` job to depend on both `sync` and `repair` jobs, preventing it from running against a potentially inconsistent branch state during the repair process.
## What

<!-- One sentence: what does this PR do? -->

## Why

<!-- One sentence: why is this change needed? -->

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Checklist

- [ ] Follows GSD style (no enterprise patterns, no filler)
- [ ] Updates CHANGELOG.md for user-facing changes
- [ ] No unnecessary dependencies added
- [ ] Works on Windows (backslash paths tested)

## Breaking Changes

None
