### PR TITLE
fix(upstream-sync): enhance PR creation and auto-merge handling for u…

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -1103,6 +1103,7 @@ jobs:
                 --head "automated/upstream-sync" --json number --jq '.[0].number' 2>/dev/null || echo "")
               if [ -z "$EXISTING_PR" ]; then
                 echo "No existing PR for automated/upstream-sync — creating one..."
+                PR_CREATE_EXIT=0
                 CREATED_PR_URL=$(gh pr create \
                   --repo "$GITHUB_REPOSITORY" \
                   --base main \
@@ -1110,9 +1111,12 @@ jobs:
                   --title "sync: upstream changes (self-heal)" \
                   --body "Automated upstream sync. Verifier errors were resolved by the self-heal pass (generator re-run)." \
                   --label "upstream-sync" \
-                  --label "automated" 2>&1) || true
+                  --label "automated" 2>&1) || PR_CREATE_EXIT=$?
                 echo "gh pr create output: $CREATED_PR_URL"
                 SYNC_PR_NUMBER=$(echo "$CREATED_PR_URL" | grep -oP '/pull/\K[0-9]+' || echo "")
+                if [ "$PR_CREATE_EXIT" -ne 0 ] && [ -z "$SYNC_PR_NUMBER" ]; then
+                  echo "::warning::gh pr create failed (exit $PR_CREATE_EXIT) and no open PR could be resolved for automated/upstream-sync. Auto-merge will be skipped."
+                fi
               else
                 echo "PR #${EXISTING_PR} already exists for automated/upstream-sync."
                 SYNC_PR_NUMBER="$EXISTING_PR"
@@ -1396,6 +1400,7 @@ jobs:
               EXISTING_PR=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
                 --head "automated/upstream-sync" --json number --jq '.[0].number' 2>/dev/null || echo "")
               if [ -z "$EXISTING_PR" ]; then
+                PR_CREATE_EXIT=0
                 CREATED_PR_URL=$(gh pr create \
                   --repo "$GITHUB_REPOSITORY" \
                   --base main \
@@ -1403,9 +1408,12 @@ jobs:
                   --title "sync: upstream changes (autonomous repair)" \
                   --body-file /tmp/pr-body.md \
                   --label "upstream-sync" \
-                  --label "automated" 2>&1) || true
+                  --label "automated" 2>&1) || PR_CREATE_EXIT=$?
                 echo "gh pr create output: $CREATED_PR_URL"
                 SYNC_PR_NUMBER=$(echo "$CREATED_PR_URL" | grep -oP '/pull/\K[0-9]+' || echo "")
+                if [ "$PR_CREATE_EXIT" -ne 0 ] && [ -z "$SYNC_PR_NUMBER" ]; then
+                  echo "::warning::gh pr create failed (exit $PR_CREATE_EXIT) and no open PR could be resolved for automated/upstream-sync. Auto-merge will be skipped."
+                fi
               else
                 SYNC_PR_NUMBER="$EXISTING_PR"
               fi


### PR DESCRIPTION
…pstream sync operations
This pull request improves the automation and reliability of the upstream sync workflow by making the pull request creation and auto-merge steps more robust. The changes ensure that the workflow correctly handles cases where a PR already exists, extracts the PR number reliably, and only attempts to enable auto-merge when appropriate.

**Improvements to PR creation and handling:**

* Refactored the PR creation step to capture the output of `gh pr create`, extract the PR number, and handle cases where the PR already exists, ensuring subsequent steps use the correct PR reference. (.github/workflows/upstream-sync.yml) [[1]](diffhunk://#diff-f21bf02175f33f2522bf5ac7944d2999c7f4ea8b8542afe361a9800eda3580e9L1106-R1128) [[2]](diffhunk://#diff-f21bf02175f33f2522bf5ac7944d2999c7f4ea8b8542afe361a9800eda3580e9L1388-R1416)
* Added logic to only enable auto-merge if a valid PR number is available, and improved warning messages to guide users if repository settings are not configured to allow auto-merge. (.github/workflows/upstream-sync.yml) [[1]](diffhunk://#diff-f21bf02175f33f2522bf5ac7944d2999c7f4ea8b8542afe361a9800eda3580e9L1106-R1128) [[2]](diffhunk://#diff-f21bf02175f33f2522bf5ac7944d2999c7f4ea8b8542afe361a9800eda3580e9L1388-R1416)

**Workflow reliability:**

* Ensured that `gh pr list` only considers open PRs when checking for an existing upstream sync PR, preventing issues with closed or merged PRs. (.github/workflows/upstream-sync.yml)
## What

<!-- One sentence: what does this PR do? -->

## Why

<!-- One sentence: why is this change needed? -->

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Checklist

- [ ] Follows GSD style (no enterprise patterns, no filler)
- [ ] Updates CHANGELOG.md for user-facing changes
- [ ] No unnecessary dependencies added
- [ ] Works on Windows (backslash paths tested)

## Breaking Changes

None
