### PR TITLE
fix(repair): reset automated/upstream-sync to main when behind to pre…

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -1058,9 +1058,20 @@ jobs:
           # The checkout step lands on main; the repair agent must operate on
           # automated/upstream-sync so the verifier sees the sync-merged content
           # and all merges/pushes go to the correct branch.
-          git fetch origin automated/upstream-sync 2>/dev/null || true
+          git fetch origin automated/upstream-sync ${{ env.DEFAULT_BRANCH }} 2>/dev/null || true
           git checkout -B automated/upstream-sync origin/automated/upstream-sync 2>/dev/null || \
             git checkout -B automated/upstream-sync origin/${{ env.DEFAULT_BRANCH }} 2>/dev/null || true
+
+          # If main is ahead of automated/upstream-sync (e.g. a prior repair PR was
+          # merged into main but automated/upstream-sync still points at an older commit),
+          # reset to main. Without this, the generator creates files that are already in
+          # main and git diff shows nothing new — so no commit is made and
+          # gh pr create fails with "no commits between main and automated/upstream-sync".
+          COMMITS_BEHIND=$(git rev-list HEAD..origin/${{ env.DEFAULT_BRANCH }} --count 2>/dev/null || echo "0")
+          if [ "$COMMITS_BEHIND" -gt 0 ]; then
+            echo "automated/upstream-sync is ${COMMITS_BEHIND} commit(s) behind ${{ env.DEFAULT_BRANCH }} — resetting to ${{ env.DEFAULT_BRANCH }} as new base."
+            git reset --hard origin/${{ env.DEFAULT_BRANCH }}
+          fi
 
           # Run initial verify to see if repair is needed.
           # Do this BEFORE the auth gate: if the verifier passes there is nothing


### PR DESCRIPTION
…vent empty PR

When main has commits that automated/upstream-sync doesn't (e.g. after a prior repair PR was merged), the repair job's generator would create files that are already in main  git diff shows nothing new, no commit is made, and gh pr create fails with 'no commits between main and automated/upstream-sync'.

Fix: detect if automated/upstream-sync is behind main at job start and reset to main as the new base. The generator then commits diverging changes on top of the correct baseline, making the PR valid.

## What

<!-- One sentence: what does this PR do? -->

## Why

<!-- One sentence: why is this change needed? -->

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Checklist

- [ ] Follows GSD style (no enterprise patterns, no filler)
- [ ] Updates CHANGELOG.md for user-facing changes
- [ ] No unnecessary dependencies added
- [ ] Works on Windows (backslash paths tested)

## Breaking Changes

None
