### PR TITLE
fix(repair): split git add per directory to prevent missing dir abort…

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -591,7 +591,9 @@ jobs:
       - name: Commit regenerated wrapper files
         if: steps.detect.outputs.no_changes != 'true' && steps.merge.outcome == 'success'
         run: |
-          git add --all .github/prompts/ .github/agents/ .github/instructions/ || true
+          git add --all .github/prompts/ 2>/dev/null || true
+          git add --all .github/agents/ 2>/dev/null || true
+          git add --all .github/instructions/ 2>/dev/null || true
           if ! git diff --cached --quiet; then
             git commit -m "chore: regenerate Copilot wrapper layer for upstream@${{ steps.detect.outputs.short_sha }}"
           else
@@ -1104,8 +1106,12 @@ jobs:
               echo "--- git status before add ---"
               git status --short .github/prompts/ scripts/ || true
               # Use --all to ensure new (untracked) files are included, not just modifications.
-              git add --all .github/prompts/ .github/agents/ .github/instructions/ || true
-              git add --all scripts/ || true
+              # Split into one call per directory — if a directory doesn't exist git add
+              # fails the entire multi-path invocation, staging nothing.
+              git add --all .github/prompts/ 2>/dev/null || true
+              git add --all .github/agents/ 2>/dev/null || true
+              git add --all .github/instructions/ 2>/dev/null || true
+              git add --all scripts/ 2>/dev/null || true
               echo "--- git diff --cached after add ---"
               git diff --cached --stat || true
               if ! git diff --cached --quiet; then


### PR DESCRIPTION
…ing all staging
This pull request updates the `.github/workflows/upstream-sync.yml` workflow to improve reliability when adding files to the git staging area. The main change is splitting multi-directory `git add` commands into separate calls for each directory, and suppressing errors if a directory does not exist. This prevents the entire add operation from failing if one directory is missing.

**Workflow reliability improvements:**

* Split multi-directory `git add` commands into separate calls for `.github/prompts/`, `.github/agents/`, and `.github/instructions/`, each with error suppression, to prevent failures when a directory is missing. [[1]](diffhunk://#diff-f21bf02175f33f2522bf5ac7944d2999c7f4ea8b8542afe361a9800eda3580e9L594-R596) [[2]](diffhunk://#diff-f21bf02175f33f2522bf5ac7944d2999c7f4ea8b8542afe361a9800eda3580e9L1107-R1114)
* Applied the same change to the `scripts/` directory in the workflow, ensuring consistency and robustness across all relevant directories.
## What

<!-- One sentence: what does this PR do? -->

## Why

<!-- One sentence: why is this change needed? -->

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Checklist

- [ ] Follows GSD style (no enterprise patterns, no filler)
- [ ] Updates CHANGELOG.md for user-facing changes
- [ ] No unnecessary dependencies added
- [ ] Works on Windows (backslash paths tested)

## Breaking Changes

None
